### PR TITLE
Add install script for system service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,19 @@ curl http://localhost:5000/check/ABC123
 ```
 
 The server responds with JSON indicating whether the license is valid.
+
+## Install as a system service
+
+Run the provided `install_service.sh` script as root to deploy PixelPatrol as a
+systemd service. The script clones the repository to `/opt/pixelpatrol`,
+installs Flask and registers a service called `pixelpatrol.service`.
+
+```bash
+sudo ./install_service.sh
+```
+
+After installation, control the service with `systemctl`:
+
+```bash
+sudo systemctl status pixelpatrol.service
+```

--- a/install_service.sh
+++ b/install_service.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+
+# This script installs PixelPatrol as a systemd service.
+# It clones the repository, installs dependencies and starts the service.
+
+REPO_URL=${REPO_URL:-"https://github.com/example/PixelPatrol.git"}
+INSTALL_DIR=${INSTALL_DIR:-"/opt/pixelpatrol"}
+SERVICE_FILE="/etc/systemd/system/pixelpatrol.service"
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run as root" >&2
+    exit 1
+fi
+
+# Clone or update the repository
+if [ ! -d "$INSTALL_DIR" ]; then
+    git clone "$REPO_URL" "$INSTALL_DIR"
+else
+    git -C "$INSTALL_DIR" pull
+fi
+
+# Install Python dependencies
+pip3 install --upgrade flask
+
+# Create systemd service
+cat > "$SERVICE_FILE" <<SERVICE
+[Unit]
+Description=PixelPatrol Licensing Server
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/python3 $INSTALL_DIR/server.py
+WorkingDirectory=$INSTALL_DIR
+Restart=always
+User=nobody
+Group=nogroup
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+# Reload systemd and enable/start the service
+systemctl daemon-reload
+systemctl enable pixelpatrol.service
+systemctl restart pixelpatrol.service
+
+echo "PixelPatrol service installed and running." 


### PR DESCRIPTION
## Summary
- add `install_service.sh` to install PixelPatrol as a systemd service
- document system service usage in `README.md`

## Testing
- `python3 -m py_compile server.py`
- `~/.local/bin/flake8 server.py || true`

------
https://chatgpt.com/codex/tasks/task_e_685ce7c837d883219a0965d99e7eb3b9