### PR TITLE
Add license management API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ curl http://localhost:5000/check/ABC123
 
 The server responds with JSON indicating whether the license is valid.
 
+## Managing Licenses
+
+PixelPatrol exposes additional endpoints for viewing, adding and deleting
+licenses. All responses are JSON.
+
+- `GET /licenses` - return the current list of licenses.
+- `POST /licenses` - add a license key. The request body should be JSON with a
+  `license` field.
+- `DELETE /licenses/<license>` - remove the specified license key.
+
+Example adding a license:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"license": "NEWKEY"}' http://localhost:5000/licenses
+```
+
 ## Install as a system service
 
 Run the `install_service.sh` script as root to deploy PixelPatrol as a

--- a/server.py
+++ b/server.py
@@ -1,5 +1,5 @@
 import json
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
@@ -18,6 +18,37 @@ def check_license(license_key):
     else:
         status = 'invalid'
     return jsonify({'license': license_key, 'status': status})
+
+
+@app.route('/licenses', methods=['GET', 'POST'])
+def manage_licenses():
+    """Return the license list or add a new license."""
+    if request.method == 'GET':
+        return jsonify({'licenses': sorted(LICENSES)})
+
+    data = request.get_json(silent=True) or {}
+    new_license = data.get('license')
+    if not new_license:
+        return jsonify({'error': 'license key required'}), 400
+    if new_license in LICENSES:
+        return jsonify({'message': 'license already exists'}), 400
+
+    LICENSES.add(new_license)
+    with open('licenses.json', 'w') as f:
+        json.dump(sorted(LICENSES), f)
+    return jsonify({'message': 'license added', 'license': new_license}), 201
+
+
+@app.route('/licenses/<license_key>', methods=['DELETE'])
+def delete_license(license_key):
+    """Delete a license key."""
+    if license_key not in LICENSES:
+        return jsonify({'error': 'license not found'}), 404
+
+    LICENSES.remove(license_key)
+    with open('licenses.json', 'w') as f:
+        json.dump(sorted(LICENSES), f)
+    return jsonify({'message': 'license deleted', 'license': license_key})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- expose APIs to list, add and delete licenses
- document new endpoints in README

## Testing
- `python3 server.py &` and exercised new `curl` endpoints

------
https://chatgpt.com/codex/tasks/task_e_685cedc114508321817d16013a1196da