### PR TITLE
Disable license management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,26 +28,14 @@ The server responds with JSON indicating whether the license is valid.
 
 ## Managing Licenses
 
-PixelPatrol exposes additional endpoints for viewing, adding and deleting
-licenses. All responses are JSON.
-
-- `GET /licenses` - return the current list of licenses.
-- `POST /licenses` - add a license key. The request body should be JSON with a
-  `license` field.
-- `DELETE /licenses/<license>` - remove the specified license key.
-
-Example adding a license:
-
-```bash
-curl -X POST -H "Content-Type: application/json" \
-  -d '{"license": "NEWKEY"}' http://localhost:5000/licenses
-```
+License keys are edited locally using the included text based interface.
+Run the `license_tui.py` script to view, add or remove keys. The web server
+does not provide endpoints for modifying licenses.
 
 ### Text interface
 
-For local administration without exposing the HTTP endpoints, run the
-`license_tui.py` script. It presents a simple curses-based UI for viewing,
-adding and removing license keys.
+The TUI presents a simple curses-based UI for viewing, adding and removing
+license keys.
 
 ```bash
 python3 license_tui.py

--- a/server.py
+++ b/server.py
@@ -1,5 +1,5 @@
 import json
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify
 
 app = Flask(__name__)
 
@@ -20,35 +20,6 @@ def check_license(license_key):
     return jsonify({'license': license_key, 'status': status})
 
 
-@app.route('/licenses', methods=['GET', 'POST'])
-def manage_licenses():
-    """Return the license list or add a new license."""
-    if request.method == 'GET':
-        return jsonify({'licenses': sorted(LICENSES)})
-
-    data = request.get_json(silent=True) or {}
-    new_license = data.get('license')
-    if not new_license:
-        return jsonify({'error': 'license key required'}), 400
-    if new_license in LICENSES:
-        return jsonify({'message': 'license already exists'}), 400
-
-    LICENSES.add(new_license)
-    with open('licenses.json', 'w') as f:
-        json.dump(sorted(LICENSES), f)
-    return jsonify({'message': 'license added', 'license': new_license}), 201
-
-
-@app.route('/licenses/<license_key>', methods=['DELETE'])
-def delete_license(license_key):
-    """Delete a license key."""
-    if license_key not in LICENSES:
-        return jsonify({'error': 'license not found'}), 404
-
-    LICENSES.remove(license_key)
-    with open('licenses.json', 'w') as f:
-        json.dump(sorted(LICENSES), f)
-    return jsonify({'message': 'license deleted', 'license': license_key})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- remove HTTP endpoints for adding/deleting licenses
- update documentation to describe local-only management

## Testing
- `python3 -m py_compile server.py license_tui.py`
- `python3 server.py` *(manual, ensure `/check` works)*

------
https://chatgpt.com/codex/tasks/task_e_685cf0caa1588321a96ad5a0df1a7a7d