### PR TITLE
Add PixelPatrol CLI alias in install script

### DIFF
--- a/install_service.sh
+++ b/install_service.sh
@@ -7,6 +7,7 @@ set -e
 REPO_URL=${REPO_URL:-"https://github.com/AlinariC/PixelPatrol.git"}
 INSTALL_DIR=${INSTALL_DIR:-"/opt/pixelpatrol"}
 SERVICE_FILE="/etc/systemd/system/pixelpatrol.service"
+ALIAS_FILE="/etc/profile.d/pixelpatrol.sh"
 
 if [ "$EUID" -ne 0 ]; then
     echo "Please run as root" >&2
@@ -45,4 +46,7 @@ systemctl daemon-reload
 systemctl enable pixelpatrol.service
 systemctl restart pixelpatrol.service
 
-echo "PixelPatrol service installed and running." 
+# Add alias for the license management TUI
+echo "alias pixelpatrol=\"sudo python3 $INSTALL_DIR/license_tui.py\"" > "$ALIAS_FILE"
+
+echo "PixelPatrol service installed and running."


### PR DESCRIPTION
## Summary
- add alias creation to install script

## Testing
- `python3 -m py_compile server.py license_tui.py`
- `bash -n install_service.sh`
- `shellcheck install_service.sh`

------
https://chatgpt.com/codex/tasks/task_e_685cf29722d083219cf8f183be0bc5f2