### PR TITLE
Auto generate license keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ PixelPacific Licensing Server for PiBells.
    git clone https://github.com/AlinariC/PixelPatrol.git
    cd PixelPatrol
    ```
-2. Edit `licenses.json` to include all valid license keys.
+2. Edit `licenses.json` or use the TUI to add new license keys. Keys are
+   automatically generated as 24-character alphanumeric strings when added
+   through the TUI.
 3. Run the server:
    ```bash
    python3 server.py
@@ -41,8 +43,9 @@ license keys.
 python3 license_tui.py
 ```
 
-Use the arrow keys to navigate, press `a` to add a new license, `d` to delete
-the selected key and `q` to quit. Changes are saved to `licenses.json`.
+Use the arrow keys to navigate, press `a` to generate and add a new license,
+`d` to delete the selected key and `q` to quit. Changes are saved to
+`licenses.json`.
 
 ## Install as a system service
 

--- a/license_tui.py
+++ b/license_tui.py
@@ -1,5 +1,7 @@
 import curses
 import json
+import random
+import string
 from pathlib import Path
 
 LICENSE_FILE = Path(__file__).parent / 'licenses.json'
@@ -50,15 +52,18 @@ def main(stdscr):
             if licenses:
                 idx = min(len(licenses) - 1, idx + 1)
         elif ch in (ord('a'), ord('A')):
-            curses.echo()
-            stdscr.addstr(len(licenses) + 4, 2, "Enter new license: ")
-            stdscr.clrtoeol()
-            new = stdscr.getstr().decode().strip()
-            curses.noecho()
-            if new and new not in licenses:
-                licenses.append(new)
-                licenses.sort()
-                idx = licenses.index(new)
+            # Auto-generate a unique 24-character alphanumeric license
+            alphabet = string.ascii_uppercase + string.digits
+            while True:
+                new = ''.join(random.choices(alphabet, k=24))
+                if new not in licenses:
+                    break
+            licenses.append(new)
+            licenses.sort()
+            idx = licenses.index(new)
+            stdscr.addstr(len(licenses) + 4, 2, f"Added license: {new}")
+            stdscr.refresh()
+            curses.napms(1000)
         elif ch in (ord('d'), ord('D')) and licenses:
             licenses.pop(idx)
             idx = min(idx, len(licenses) - 1)


### PR DESCRIPTION
## Summary
- automatically generate 24 character keys when adding a license
- document new behaviour in README

## Testing
- `python3 -m py_compile license_tui.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_685cf48c695c8321b6364dfd845ccb54