### PR TITLE
Implement email-based license validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ PixelPacific Licensing Server for PiBells.
    ```bash
    python3 server.py
    ```
-4. The server listens on port 5000. Clients can check a license by sending a GET request to `/check/<license_key>`.
+4. The server listens on port 5000. Clients can check a license by sending a GET request to `/check/<license_key>?email=<registered_email>`.
 
 Example:
 ```bash
-curl http://localhost:5000/check/ABC123
+curl "http://localhost:5000/check/ABC123?email=user@example.com"
 ```
 
-The server responds with JSON indicating whether the license is valid or
-expired and includes the stored customer information.
+The server responds with JSON indicating whether the license is valid and
+provides the expiration date. Only the status (`VALID` or `INVALID`) and the
+expiration date are returned to the client.
 
 ## Managing Licenses
 

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, date
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
@@ -23,10 +23,11 @@ except FileNotFoundError:
 
 @app.route('/check/<license_key>')
 def check_license(license_key):
-    """Check if the provided license key is valid."""
+    """Validate a license key using the provided email."""
     info = LICENSES.get(license_key)
-    if not info:
-        return jsonify({'license': license_key, 'status': 'invalid'})
+    email = request.args.get('email', '').strip().lower()
+    if not info or info.get('email', '').lower() != email:
+        return jsonify({'status': 'INVALID'})
 
     expired = False
     exp = info.get('expires')
@@ -37,12 +38,9 @@ def check_license(license_key):
         except ValueError:
             pass
 
-    status = 'valid' if not expired else 'expired'
+    status = 'VALID' if not expired else 'INVALID'
     payload = {
-        'license': license_key,
         'status': status,
-        'name': info.get('name'),
-        'email': info.get('email'),
         'expires': exp,
     }
     return jsonify(payload)


### PR DESCRIPTION
## Summary
- require users to provide an email when checking a license
- return only status and expiry date
- document updated API usage in README

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_685cf78f26808321a9d1562154effb73