### PR TITLE
Fix update script for local licenses

### DIFF
--- a/install_service.sh
+++ b/install_service.sh
@@ -24,6 +24,7 @@ fi
 PRESERVE=0
 if [ -f "$INSTALL_DIR/$LICENSE_FILE" ]; then
     cp "$INSTALL_DIR/$LICENSE_FILE" "/tmp/$LICENSE_FILE.bak"
+    git -C "$INSTALL_DIR" checkout -- "$LICENSE_FILE"
     PRESERVE=1
 fi
 


### PR DESCRIPTION
## Summary
- ensure license file changes don't block `git pull` in install script

## Testing
- `bash -n install_service.sh`
- `python3 -m py_compile server.py license_tui.py`


------
https://chatgpt.com/codex/tasks/task_e_685cfdc89a0883218e0a250e12c0cfb6