### PR TITLE
Update license manager display

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ does not provide endpoints for modifying licenses.
 The text interface provides a curses-based UI for viewing, adding and
 removing license keys. The layout now uses a framed list with a help bar at
 the bottom showing the available actions. When adding a key you will be
-prompted for the customer name, email and expiration date.
+prompted for the customer name, email and expiration date. The list displays
+each license key along with the associated name, email address and
+expiration date.
 
 ```bash
 python3 license_tui.py

--- a/license_tui.py
+++ b/license_tui.py
@@ -54,13 +54,23 @@ def draw_menu(stdscr, licenses, idx):
     stdscr.attroff(curses.A_BOLD)
 
     # Column headers
-    header = "KEY".ljust(25) + "NAME".ljust(22) + "EXPIRES"
+    header = (
+        "KEY".ljust(25)
+        + "NAME".ljust(18)
+        + "EMAIL".ljust(23)
+        + "EXPIRES"
+    )
     stdscr.addstr(2, 2, header[:width - 4], curses.A_UNDERLINE)
 
     # License entries
     for i, lic in enumerate(licenses):
         attr = curses.A_REVERSE if i == idx else curses.A_NORMAL
-        row = f"{lic['key']:<24} {lic['name']:<20} {lic['expires']}"
+        row = (
+            f"{lic['key']:<24} "
+            f"{lic['name']:<17} "
+            f"{lic['email']:<22} "
+            f"{lic['expires']}"
+        )
         stdscr.addstr(3 + i, 2, row[:width - 4], attr)
 
     help_line = "[A] Add  [D] Delete  [Q] Quit  Up/Down Navigate"


### PR DESCRIPTION
## Summary
- show email column in the license manager TUI
- mention columns in README

## Testing
- `python3 -m py_compile license_tui.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_685cfee6203c8321be61e4a732e8f617