### PR TITLE
Add name to server response

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ curl "http://localhost:5000/check/ABC123?email=user@example.com"
 ```
 
 The server responds with JSON indicating whether the license is valid and
-provides the expiration date. Only the status (`VALID` or `INVALID`) and the
-expiration date are returned to the client.
+provides the expiration date and customer name. The payload includes the
+`status` (`VALID` or `INVALID`), `expires` date and the registered `name`.
 
 ## Managing Licenses
 

--- a/server.py
+++ b/server.py
@@ -42,6 +42,7 @@ def check_license(license_key):
     payload = {
         'status': status,
         'expires': exp,
+        'name': info.get('name', ''),
     }
     return jsonify(payload)
 


### PR DESCRIPTION
## Summary
- include the license holder's name in the `/check` endpoint
- document the updated JSON response in the README

## Testing
- `python3 -m py_compile server.py license_tui.py`

------
https://chatgpt.com/codex/tasks/task_e_6869dd5ddcb88321b46ccb373c03a40b